### PR TITLE
Ability to add class to the mark

### DIFF
--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -125,6 +125,9 @@
 					case 'regexp':
 						input = this.markRegExp(input, payload);
 						break;
+		                    	case 'object':
+		                	 	input = this.markObject(input, payload);
+		                		break;
 					default:
 						throw 'Unrecognized payload type returned from onInput callback.';
 				}
@@ -177,6 +180,16 @@
 		markRegExp: function(input, payload) {
 			return input.replace(payload, '<mark>$&</mark>');
 		},
+
+	        markObject: function(input, payload) {
+	            for (var key in payload) {
+	                // skip loop if the property is from prototype
+	                if (!payload.hasOwnProperty(key)) continue;
+	                var regex = payload[key];
+	                input = input.replace(regex, '<mark class="'+key+'">$&</mark>');
+	            }
+	            return input;
+	        },
 
 		destroy: function() {
 			this.$backdrop.remove();


### PR DESCRIPTION
I was in need to add a classname to the mark tags, this way you could highlight different matches in different styles. 
usage example:

```
        $('textarea').highlightWithinTextarea(function() {
            return {
                    'mark-number': /\d+/g,
                    'mark-capitalwords': /[A-Z].*\b/g
                   };
        });
```
