### PR TITLE
Fix missing style transfer from existing textarea to hwt containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,6 @@ Use for visibility, positioning, and background.
 - `margin`
 - `background`
 
-### .hwt-content
-
-Use for sizing and text formatting.
-- `width`
-- `height`
-- `padding`
-- `border`
-- `color`
-- `font`
-
 ### .hwt-content mark
 
 Use for highlighted text. Generally, stuff that doesn't change size is fine.
@@ -54,6 +44,8 @@ Use for highlighted text. Generally, stuff that doesn't change size is fine.
 - `box-shadow`
 
 Changes to `color` won't be visible, since text in the textarea covers colored text in the highlights.
+
+Feel free to style your actual `textarea` element as you like.
 
 ## Updating
 

--- a/jquery.highlight-within-textarea.css
+++ b/jquery.highlight-within-textarea.css
@@ -12,7 +12,6 @@
 	right: -99px !important;
 	bottom: 0 !important;
 	left: 0 !important;
-	margin: 0 !important;
 	padding: 0 99px 0 0 !important;
 	overflow-x: hidden !important;
 	overflow-y: auto !important;

--- a/jquery.highlight-within-textarea.css
+++ b/jquery.highlight-within-textarea.css
@@ -30,7 +30,6 @@
 	display: block !important;
 	position: relative !important;
 	margin: 0 !important;
-	border-radius: 0;
 	overflow-x: hidden !important;
 	overflow-y: auto !important;
 }

--- a/jquery.highlight-within-textarea.css
+++ b/jquery.highlight-within-textarea.css
@@ -3,6 +3,7 @@
 	position: relative;
 	overflow: hidden !important;
 	-webkit-text-size-adjust: none !important;
+	padding: 0 !important;
 }
 
 .hwt-backdrop {
@@ -11,7 +12,8 @@
 	right: -99px !important;
 	bottom: 0 !important;
 	left: 0 !important;
-	padding-right: 99px !important;
+	margin: 0 !important;
+	padding: 0 99px 0 0 !important;
 	overflow-x: hidden !important;
 	overflow-y: auto !important;
 }
@@ -19,6 +21,7 @@
 .hwt-highlights {
 	width: auto !important;
 	height: auto !important;
+	margin: 0 !important;
 	border-color: transparent !important;
 	white-space: pre-wrap !important;
 	word-wrap: break-word !important;
@@ -35,7 +38,8 @@
 }
 
 .hwt-content {
-	border: 1px solid;
+	border-width: 1px;
+	border-style: solid;
 	background: none transparent !important;
 }
 

--- a/jquery.highlight-within-textarea.css
+++ b/jquery.highlight-within-textarea.css
@@ -29,10 +29,8 @@
 .hwt-input {
 	display: block !important;
 	position: relative !important;
-	margin: 0;
-	padding: 0;
+	margin: 0 !important;
 	border-radius: 0;
-	font: inherit;
 	overflow-x: hidden !important;
 	overflow-y: auto !important;
 }

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -53,25 +53,24 @@
 			return 'other';
 		},
 
-		getHighlightsDivCssFix: function(currentTextarea) {
-			const textareaStyle = window.getComputedStyle(currentTextarea);
+		getHighlightsDivCssFix: function(textareaStyle) {
 			return {
 				'font-size': textareaStyle.getPropertyValue('font-size'),
 				'font-family': textareaStyle.getPropertyValue('font-family'),
 				'line-height': textareaStyle.getPropertyValue('line-height'),
-				'padding': textareaStyle.getPropertyValue('padding')
+				'letter-spacing': textareaStyle.getPropertyValue('letter-spacing'),
+				'padding': textareaStyle.getPropertyValue('padding'),
+				'border': textareaStyle.getPropertyValue('border')
 			};
 		},
 
-		getBackdropDivCssFix: function(currentTextarea) {
-			const textareaStyle = window.getComputedStyle(currentTextarea);
+		getBackdropDivCssFix: function(textareaStyle) {
 			return {
 				'background-color': textareaStyle.getPropertyValue('background-color')
 			};
 		},
 
-		getContainerDivCssFix: function(currentTextarea) {
-			const textareaStyle = window.getComputedStyle(currentTextarea);
+		getContainerDivCssFix: function(textareaStyle) {
 			return {
 				'margin': textareaStyle.getPropertyValue('margin')
 			};
@@ -79,9 +78,10 @@
 
 		generate: function() {
 			// First save styles from existing textarea element
-			const highlightsDivCssFix = this.getHighlightsDivCssFix(this.$el.get(0));
-			const backdropDivCssFix = this.getBackdropDivCssFix(this.$el.get(0));
-			const containerDivCssFix = this.getContainerDivCssFix(this.$el.get(0));
+			const textareaStyle = window.getComputedStyle(this.$el.get(0));
+			const highlightsDivCssFix = this.getHighlightsDivCssFix(textareaStyle);
+			const backdropDivCssFix = this.getBackdropDivCssFix(textareaStyle);
+			const containerDivCssFix = this.getContainerDivCssFix(textareaStyle);
 
 			this.$el
 				.addClass(ID + '-input ' + ID + '-content')

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -83,18 +83,34 @@
 		},
 
 		getTextareaCssFix: function(textareaStyle) {
-			return {
-				'width': textareaStyle.getPropertyValue('width'),
-				'height': textareaStyle.getPropertyValue('height')
-			};
+			// Percent-based width and height will result in different values,
+			// 	so we should fix the computed width and height (unless already set,
+			//	which would later break resizable areas after plugin 'destroy' event)
+			const cssFix = {};
+			const elementStyle = this.$el.get(0).style;
+			if (!elementStyle.width) {
+				cssFix.width = textareaStyle.getPropertyValue('width');
+				this.$el.data('fix-width', true);
+			}
+			if (!elementStyle.height) {
+				cssFix.height = textareaStyle.getPropertyValue('height');
+				this.$el.data('fix-height', true);
+			}
+			return cssFix;
 		},
 
 		getTextareaCssFixReversed: function() {
 			/* Used to remove the fixed applied width and height properties */
-			return {
-				'width': "",
-				'height': ""
-			};
+			const cssFix = {};
+			if (this.$el.data('fix-width')) {
+				cssFix.width = ""; // unset
+				this.$el.removeData('fix-width');
+			}
+			if (this.$el.data('fix-height')) {
+				cssFix.height = ""; // unset
+				this.$el.removeData('fix-height');
+			}
+			return cssFix;
 		},
 
 		generate: function() {

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -69,7 +69,8 @@
 
 		getBackdropDivCssFix: function(textareaStyle) {
 			return {
-				'background-color': textareaStyle.getPropertyValue('background-color')
+				'background-color': textareaStyle.getPropertyValue('background-color'),
+				'margin': '0px'
 			};
 		},
 

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -86,14 +86,25 @@
 			// Percent-based width and height will result in different values,
 			// 	so we should fix the computed width and height (unless already set,
 			//	which would later break resizable areas after plugin 'destroy' event)
+			// This value also needs to include the possibility of a scrollbar
 			const cssFix = {};
 			const elementStyle = this.$el.get(0).style;
 			if (!elementStyle.width) {
-				cssFix.width = textareaStyle.getPropertyValue('width');
+				const width = parseInt(textareaStyle.getPropertyValue('width'), 10);
+				const borderLeftWidth = parseInt(textareaStyle.getPropertyValue('border-left-width'), 10);
+				const borderRightWidth = parseInt(textareaStyle.getPropertyValue('border-right-width'), 10);
+				const scrollBarWidth = (this.$el.get(0).offsetWidth -
+					this.$el.get(0).clientWidth - borderLeftWidth - borderRightWidth);
+				cssFix.width = (width + scrollBarWidth) + 'px';
 				this.$el.data('fix-width', true);
 			}
 			if (!elementStyle.height) {
-				cssFix.height = textareaStyle.getPropertyValue('height');
+				const height = parseInt(textareaStyle.getPropertyValue('height'), 10);
+				const borderTopWidth = parseInt(textareaStyle.getPropertyValue('border-top-width'), 10);
+				const borderBottomWidth = parseInt(textareaStyle.getPropertyValue('border-bottom-width'), 10);
+				const scrollBarHeight = (this.$el.get(0).offsetHeight -
+					this.$el.get(0).clientHeight - borderTopWidth - borderBottomWidth);
+				cssFix.height = (height + scrollBarHeight) + 'px';
 				this.$el.data('fix-height', true);
 			}
 			return cssFix;

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -59,8 +59,11 @@
 				'font-family': textareaStyle.getPropertyValue('font-family'),
 				'line-height': textareaStyle.getPropertyValue('line-height'),
 				'letter-spacing': textareaStyle.getPropertyValue('letter-spacing'),
-				'padding': textareaStyle.getPropertyValue('padding'),
-				'border': textareaStyle.getPropertyValue('border')
+				'border': textareaStyle.getPropertyValue('border'),
+				'padding-top': textareaStyle.getPropertyValue('padding-top'),
+				'padding-right': textareaStyle.getPropertyValue('padding-right'),
+				'padding-bottom': textareaStyle.getPropertyValue('padding-bottom'),
+				'padding-left': textareaStyle.getPropertyValue('padding-left'),
 			};
 		},
 
@@ -72,7 +75,10 @@
 
 		getContainerDivCssFix: function(textareaStyle) {
 			return {
-				'margin': textareaStyle.getPropertyValue('margin')
+				'margin-top': textareaStyle.getPropertyValue('margin-top'),
+				'margin-right': textareaStyle.getPropertyValue('margin-right'),
+				'margin-bottom': textareaStyle.getPropertyValue('margin-bottom'),
+				'margin-left': textareaStyle.getPropertyValue('margin-left')
 			};
 		},
 

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -82,15 +82,32 @@
 			};
 		},
 
+		getTextareaCssFix: function(textareaStyle) {
+			return {
+				'width': textareaStyle.getPropertyValue('width'),
+				'height': textareaStyle.getPropertyValue('height')
+			};
+		},
+
+		getTextareaCssFixReversed: function() {
+			/* Used to remove the fixed applied width and height properties */
+			return {
+				'width': "",
+				'height': ""
+			};
+		},
+
 		generate: function() {
 			// First save styles from existing textarea element
 			const textareaStyle = window.getComputedStyle(this.$el.get(0));
 			const highlightsDivCssFix = this.getHighlightsDivCssFix(textareaStyle);
 			const backdropDivCssFix = this.getBackdropDivCssFix(textareaStyle);
 			const containerDivCssFix = this.getContainerDivCssFix(textareaStyle);
+			const textareaCssFix = this.getTextareaCssFix(textareaStyle);
 
 			this.$el
 				.addClass(ID + '-input ' + ID + '-content')
+				.css(textareaCssFix)
 				.on('input.' + ID, this.handleInput.bind(this))
 				.on('scroll.' + ID, this.handleScroll.bind(this));
 
@@ -375,9 +392,11 @@
 
 		destroy: function() {
 			this.$backdrop.remove();
+			const textareaCssFixReversed = this.getTextareaCssFixReversed();
 			this.$el
 				.unwrap()
 				.removeClass(ID + '-content ' + ID + '-input')
+				.css(textareaCssFixReversed)
 				.off(ID)
 				.removeData(ID);
 		},

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -57,6 +57,7 @@
 			return {
 				'font-size': textareaStyle.getPropertyValue('font-size'),
 				'font-family': textareaStyle.getPropertyValue('font-family'),
+				'font-weight': textareaStyle.getPropertyValue('font-weight'),
 				'line-height': textareaStyle.getPropertyValue('line-height'),
 				'letter-spacing': textareaStyle.getPropertyValue('letter-spacing'),
 				'border': textareaStyle.getPropertyValue('border'),

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -53,18 +53,50 @@
 			return 'other';
 		},
 
+		getHighlightsDivCssFix: function(currentTextarea) {
+			const textareaStyle = window.getComputedStyle(currentTextarea);
+			return {
+				'font-size': textareaStyle.getPropertyValue('font-size'),
+				'font-family': textareaStyle.getPropertyValue('font-family'),
+				'line-height': textareaStyle.getPropertyValue('line-height'),
+				'padding': textareaStyle.getPropertyValue('padding')
+			};
+		},
+
+		getBackdropDivCssFix: function(currentTextarea) {
+			const textareaStyle = window.getComputedStyle(currentTextarea);
+			return {
+				'background-color': textareaStyle.getPropertyValue('background-color')
+			};
+		},
+
+		getContainerDivCssFix: function(currentTextarea) {
+			const textareaStyle = window.getComputedStyle(currentTextarea);
+			return {
+				'margin': textareaStyle.getPropertyValue('margin')
+			};
+		},
+
 		generate: function() {
+			// First save styles from existing textarea element
+			const highlightsDivCssFix = this.getHighlightsDivCssFix(this.$el.get(0));
+			const backdropDivCssFix = this.getBackdropDivCssFix(this.$el.get(0));
+			const containerDivCssFix = this.getContainerDivCssFix(this.$el.get(0));
+
 			this.$el
 				.addClass(ID + '-input ' + ID + '-content')
 				.on('input.' + ID, this.handleInput.bind(this))
 				.on('scroll.' + ID, this.handleScroll.bind(this));
 
-			this.$highlights = $('<div>', { class: ID + '-highlights ' + ID + '-content' });
+			this.$highlights = $('<div>', { class: ID + '-highlights ' + ID + '-content' })
+				.css(highlightsDivCssFix);
 
 			this.$backdrop = $('<div>', { class: ID + '-backdrop' })
+				.css(backdropDivCssFix)
 				.append(this.$highlights);
 
 			this.$container = $('<div>', { class: ID + '-container' })
+				.css(containerDivCssFix)
 				.insertAfter(this.$el)
 				.append(this.$backdrop, this.$el) // moves $el into $container
 				.on('scroll', this.blockContainerScroll.bind(this));

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -339,7 +339,7 @@
 			this.$backdrop.remove();
 			this.$el
 				.unwrap()
-				.removeClass(ID + '-text ' + ID + '-input')
+				.removeClass(ID + '-content ' + ID + '-input')
 				.off(ID)
 				.removeData(ID);
 		},


### PR DESCRIPTION
This pull request fixes a couple of CSS bugs in the original plugin. 

To exactly match our text overlay we must ensure that the two text containers have the same styling. For textareas that already have certain line-height and font CSS properties set, we must ensure that these are copied to our new containers, so that both text overlay perfectly. 

This pull request also fixes previously transparent background - for dark (or any non-white) websites, this would modify the appearance of textareas and make them hard to read.