### PR TITLE
add partial highlight functionality

### DIFF
--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -189,7 +189,13 @@
 			let ranges = [];
 			let match;
 			while (match = regex.exec(input), match !== null) {
-				ranges.push([match.index, match.index + match[0].length]);
+				if (match[1]) {
+					let groupStartIndex = match.index + match[0].indexOf(match[1]);
+					let groupEndIndex = groupStartIndex + match[1].length;
+					ranges.push([groupStartIndex, groupEndIndex]);
+				} else {
+					ranges.push([match.index, match.index + match[0].length]);
+				}
 				if (!regex.global) {
 					// non-global regexes do not increase lastIndex, causing an infinite loop,
 					// but we can just break manually after the first match


### PR DESCRIPTION
I couldn't find this functionality in current project, so I added it. 
If any regular expression passed to function contains capturing group, only group contents will be highlighted.
Example:
![image](https://user-images.githubusercontent.com/10151624/31015514-dcb1ffcc-a520-11e7-96b8-b04a1ab1cf2a.png)
![image](https://user-images.githubusercontent.com/10151624/31015526-e7782030-a520-11e7-86d3-07376e99a04d.png)
