### PR TITLE
Regexp non-capturing groups fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,17 @@ $('.regex-example').highlightWithinTextarea({
 		</section>
 
 		<section>
+			<h2>RegExp With Non-Capturing Groups</h2>
+			<p>If you want to use <code>(?:)</code> (non-capturing groups), use grouping <code>()</code> for all of the other parts.</p>
+			<textarea class="regex-non-capturing-example">This a sentence. After the sentence, there is this sentence.</textarea>
+			<script>
+$('.regex-non-capturing-example').highlightWithinTextarea({
+    highlight: /(?:\. )(After the sentence)/
+});
+			</script>
+		</section>
+
+		<section>
 			<h2>Array of Two Numbers (Range)</h2>
 			<p>An array of exactly two numbers is treated as a range. Highlighting starts at the first character index (inclusive) and ends at the second character index (exclusive).</p>
 			<textarea class="range-example">abcdefgh</textarea>

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -185,7 +185,36 @@
 			return this.getRanges(input, func(input));
 		},
 
+		getRegExpRangesWithNonCapturingGroups: function(input, regex) {
+			let ranges = [];
+			let match;
+			let capturedGroups;
+			let beginIndex, endIndex;
+			while (match = regex.exec(input), match !== null) {
+				beginIndex = match.index;
+				endIndex = match.index + match[0].length;
+				capturedGroups = '';
+				for (let i = 1; i < match.length; i++) {
+					capturedGroups += match[i];
+				}
+				if (capturedGroups !== '') {
+					beginIndex = match.index + match[0].search(capturedGroups);
+					endIndex = beginIndex + capturedGroups.length;
+				}
+				ranges.push([beginIndex, endIndex]);
+				if (!regex.global) {
+					// non-global regexes do not increase lastIndex, causing an infinite loop,
+					// but we can just break manually after the first match
+					break;
+				}
+			}
+			return ranges;
+		},
+
 		getRegExpRanges: function(input, regex) {
+			if (/.*\(\?:.*\).*/.test(regex)) {
+				return this.getRegExpRangesWithNonCapturingGroups(input, regex);
+			}
 			let ranges = [];
 			let match;
 			while (match = regex.exec(input), match !== null) {


### PR DESCRIPTION
While using non-capturing groups, it was highlighting the non-captured parts as well. With this fix, it only highlights the captured parts.