### PR TITLE
Add support for callbacks + some other misc. changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,21 +178,46 @@ $('.function-example').highlightWithinTextarea({
 			<p>Any type mentioned here can be put in an object wrapper with <code>highlight</code> and <code>className</code> properties. This lets you set CSS classes in the highlight markup for custom styling, such as changing the highlight color.</p>
 			<textarea class="class-example">Here's a blueberry. There's a strawberry. Surprise, it's a banananana!</textarea>
 			<script>
-$('.class-example').highlightWithinTextarea({
-    highlight: [
-        {
-            highlight: 'strawberry',
-            className: 'red'
-        },
-        {
-            highlight: 'blueberry',
-            className: 'blue'
-        },
-        {
-            highlight: /ba(na)*/gi,
-            className: 'yellow'
-        }
-    ]
+				$('.class-example').highlightWithinTextarea({
+					highlight: [
+						{
+							highlight: 'strawberry',
+							className: 'red'
+						},
+						{
+							highlight: 'blueberry',
+							className: 'blue'
+						},
+						{
+							highlight: /ba(na)*/gi,
+							className: 'yellow'
+						}
+					]
+				});
+			</script>
+		</section>
+
+		<section>
+			<h2>Custom Callback</h2>
+			<p>By providing a custom callback, you can execute a function on all created <code>mark</code> elements. Observe:</p>
+			<textarea class="callback-example">Here's an example that matches CSS hex color codes. #ff0000. #00c2ff.</textarea>
+			<script>
+$('.callback-example').highlightWithinTextarea({
+	highlight: [
+		{
+			highlight: /(?!\b)#([0-9a-f]{6}|[0-9a-f]{3})\b/gi, // matches CSS hex colors in the form of #rgb or #rrggbb
+			callback: function(mark, index, match, markPosition) {
+				// `mark` is the mark element
+				// `index` is the index of the element
+				// `match` is the regex match, if any
+				// `markPosition` is the position of the start of the mark
+
+				console.log('mark: %o, index: %d, match: %O, mark position: %d', mark, index, match, markPosition)
+
+				mark.style.backgroundColor = mark.innerHTML
+			}
+		}
+	]
 });
 			</script>
 		</section>

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -332,7 +332,7 @@
 
 			this.$highlights.html(input);
 
-			$('> mark', this.$highlights).each(function(index, mark) {
+			$('mark', this.$highlights).each(function(index, mark) {
 				var boundary = boundaries[+mark.getAttribute('data-boundary-index')]
 
 				if (boundary.callback) {

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -189,7 +189,7 @@
 			let ranges = [];
 			let match;
 			while (match = regex.exec(input), match !== null) {
-				ranges.push([match.index, match.index + match[0].length]);
+				ranges[ranges.push([match.index, match.index + match[0].length]) - 1].match = match;
 				if (!regex.global) {
 					// non-global regexes do not increase lastIndex, causing an infinite loop,
 					// but we can just break manually after the first match
@@ -227,6 +227,19 @@
 					}
 				});
 			}
+			if (custom.callback) {
+				ranges.forEach(function(range) {
+					// call all handlers
+					if (range.callback) {
+						range.callback = function() {
+							range.callback(arguments);
+							custom.callback(arguments);
+						};
+					} else {
+						range.callback = custom.callback;
+					}
+				});
+			}
 			return ranges;
 		},
 
@@ -252,7 +265,9 @@
 				boundaries.push({
 					type: 'start',
 					index: range[0],
-					className: range.className
+					className: range.className,
+					callback: range.callback,
+					match: range.match
 				});
 				boundaries.push({
 					type: 'stop',
@@ -292,10 +307,10 @@
 			});
 
 			// this keeps scrolling aligned when input ends with a newline
-			input = input.replace(/\n(\{\{hwt-mark-stop\}\})?$/, '\n\n$1');
+			input = input.replace(/\n({{hwt-mark-stop}})?$/, '\n\n$1');
 
 			// encode HTML entities
-			input = input.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			input = input.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 			if (this.browser === 'ie') {
 				// IE/Edge wraps whitespace differently in a div vs textarea, this fixes it
@@ -303,19 +318,29 @@
 			}
 
 			// replace start tokens with opening <mark> tags with class name
-			input = input.replace(/\{\{hwt-mark-start\|(\d+)\}\}/g, function(match, submatch) {
+			input = input.replace(/{{hwt-mark-start\|(\d+)}}/g, function(match, submatch) {
 				var className = boundaries[+submatch].className;
 				if (className) {
-					return '<mark class="' + className + '">';
+					return '<mark class="' + className + '" data-boundary-index=' + submatch + '>';
 				} else {
-					return '<mark>';
+					return '<mark data-boundary-index=' + submatch + '>';
 				}
 			});
 
 			// replace stop tokens with closing </mark> tags
-			input = input.replace(/\{\{hwt-mark-stop\}\}/g, '</mark>');
+			input = input.replace(/{{hwt-mark-stop}}/g, '</mark>');
 
 			this.$highlights.html(input);
+
+			$('> mark', this.$highlights).each(function(index, mark) {
+				var boundary = boundaries[+mark.getAttribute('data-boundary-index')]
+
+				console.log(boundary)
+
+				if (boundary.callback) {
+					boundary.callback(mark, index, boundary.match, boundary.index)
+				}
+			})
 		},
 
 		handleScroll: function() {

--- a/jquery.highlight-within-textarea.js
+++ b/jquery.highlight-within-textarea.js
@@ -335,8 +335,6 @@
 			$('> mark', this.$highlights).each(function(index, mark) {
 				var boundary = boundaries[+mark.getAttribute('data-boundary-index')]
 
-				console.log(boundary)
-
 				if (boundary.callback) {
 					boundary.callback(mark, index, boundary.match, boundary.index)
 				}


### PR DESCRIPTION
- Prevent HTML entities from offsetting output
  - ![image](https://user-images.githubusercontent.com/4723091/43055118-a6ee3c2c-8de9-11e8-9ecf-ea272c137706.png)
- Remove redundant escapes from regexes
  - `{` and `}` do not need to be escaped in JavaScript RegExps
- Add support for callbacks
  - ![image](https://user-images.githubusercontent.com/4723091/43055139-cadd3390-8de9-11e8-9c18-86e5924ab7ad.png)
- Add example to demo page
  - See above image.